### PR TITLE
'numpy/arrayobject.h' file not found, solved by changing setup.py

### DIFF
--- a/code/setup.py
+++ b/code/setup.py
@@ -1,7 +1,10 @@
+from distutils.core import setup, Extension
 import numpy
-from distutils.core import setup
-from Cython.Build import cythonize
 
 setup(
-    ext_modules = cythonize("model.pyx"),
-    include_dirs=[numpy.get_include()])
+    ext_modules=[
+        Extension("model", ["model.c"],
+                  include_dirs=[numpy.get_include()]),
+    ],
+)
+

--- a/code/setup.py
+++ b/code/setup.py
@@ -1,10 +1,13 @@
 from distutils.core import setup, Extension
+from Cython.Build import cythonize
 import numpy
+
+cythonize("model.pyx")
 
 setup(
     ext_modules=[
-        Extension("model", ["model.c"],
-                  include_dirs=[numpy.get_include()]),
-    ],
+        Extension("model", ["model.c"], include_dirs=[numpy.get_include()])
+    ]
 )
+
 


### PR DESCRIPTION
When I followed the instructions in code/README.md and attempted to compile the model like this:

python setup.py build_ext --inplace

I got this error:

Cythonizing model.pyx
running build_ext
building 'model' extension
clang -fno-strict-aliasing -fno-common -dynamic -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -arch x86_64 -I/usr/local/include -I/usr/local/opt/openssl/include -I/usr/local/opt/sqlite/include -I/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c model.c -o build/temp.macosx-10.10-x86_64-2.7/model.o
model.c:265:10: fatal error: 'numpy/arrayobject.h' file not found
# include "numpy/arrayobject.h"

^
1 error generated.
error: command 'clang' failed with exit status 1

The word on the street at stackoverflow is that include_dirs sometimes gets ignored in the latest version of distutils, see dashesy's comment here:

http://stackoverflow.com/questions/20333128/cimport-gives-fatal-error-numpy-arrayobject-h-file-not-found

I decided to try using Extension in setup.py to specify include_dirs and it worked!  If someone could be so kind as to try this out and confirm it works for them as well then this change should be merged into the repo so others do not have to repeat this debugging process.
